### PR TITLE
fix go module version

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/actionutils/sigspy
+module github.com/actionutils/sigspy/v2
 
 go 1.24.2
 


### PR DESCRIPTION
ERROR:
failed to proxy module: exit status 1: go:
github.com/actionutils/sigspy@v2.0.0: invalid version: module contains a
go.mod file, so module path must match major version
("github.com/actionutils/sigspy/v2")
