### PR TITLE
fix: remove accidentally added -pretty flag

### DIFF
--- a/main.go
+++ b/main.go
@@ -486,7 +486,6 @@ func detectAndParse(data []byte, mode string) (*x509.Certificate, *CMSSummary, *
 
 func main() {
 	inputFormat := flag.String("input-format", "auto", "Input format: auto, pkcs7, der, pem")
-	pretty := flag.Bool("pretty", false, "Pretty-print JSON output")
 	flag.Parse()
 
 	// Read all stdin
@@ -524,9 +523,6 @@ func main() {
 	}
 
 	enc := json.NewEncoder(os.Stdout)
-	if *pretty {
-		enc.SetIndent("", "  ")
-	}
 	if err := enc.Encode(out); err != nil {
 		log.Fatalf("Failed to marshal JSON: %v", err)
 	}


### PR DESCRIPTION
## Summary
- Removed the accidentally added `-pretty` flag from the CLI
- Cleaned up related JSON formatting logic

## Test plan
- [ ] Build the project: `go build -v -o sigspy main.go`
- [ ] Run existing test commands to ensure functionality remains intact
- [ ] Verify JSON output is still properly formatted (compact, single line)

🤖 Generated with [Claude Code](https://claude.ai/code)